### PR TITLE
Relax BTP TF provider version constraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.4.0"
+      version = "~> 1.4"
     }
   }
 }


### PR DESCRIPTION
Allow the usage of higher minor versions of the provider to avoid a version conflict when the using TF config or another module requires a higher version.